### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# new comment
 NCS_VERSION=v2.8.0
 
 ROOT_HASH=`realpath . | md5sum | sed 's/ .*//g'`


### PR DESCRIPTION
Ref forums post https://forum.ultimatehackingkeyboard.com/t/ran-out-of-macro-space/2000

Improves macro storage and execution efficiency.

### Problem
32k of macro space is insufficient for some users.

### Possible solutions
(Based on assumption that macros are stored as plain yext)
- tokenize macro keywords at save time/revert at send to agent time, escape special chars used for marking tokens
- offer in Agent to minify macros, either 1 at a time or "minify all" (not great for readability
- tokenize whitespace (every 4 spaces, tokenize as tab or something)

(Assumes the memory capacity is artificialy limited. Turns out it is, but only a little)
- increase the allotted memory